### PR TITLE
Add a deexclude parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ This is a tslint rule that warns about focussed Jasmine tests - fdescribe and fi
 (defocus) app.ts[8, 5]: Calls to 'fit' are not allowed.
 ```
 
+You can add the `deexclude` parameter to warn also for `xdescribe` and `xit`:
+```
+"rules": {
+    "defocus": [true, "deexclude"],
+    ...
+```
+
 ## Dependencies
 
 Version 2.0.x of this rule requires version 5.x of tslint.

--- a/src/defocusRule.ts
+++ b/src/defocusRule.ts
@@ -1,40 +1,74 @@
 import * as Lint from "tslint";
 import * as ts from "typescript";
 
+// tslint:disable-next-line:interface-name
+interface Options {
+    deexclude: boolean;
+}
+
 export class Rule extends Lint.Rules.AbstractRule {
 
     public static metadata: Lint.IRuleMetadata = {
         /* tslint:disable:object-literal-sort-keys */
         ruleName: "defocus",
-        description: "Bans the use of `fdescribe` and 'fit' Jasmine functions.",
+        description: "Bans the use of `fdescribe` and `fit` Jasmine functions.",
         rationale: "It is all too easy to mistakenly commit a focussed Jasmine test suite or spec.",
-        options: null,
-        optionsDescription: "Not configurable.",
+        options: {
+            type: "array",
+            items: [
+                {
+                    type: "string",
+                    enum: ["deexclude"],
+                },
+            ],
+            additionalItems: false,
+        },
+        optionExamples: [
+            [true],
+            [true, "deexclude"],
+        ],
+        optionsDescription: "A `deexclude` argument can be added to bans the use of `xdescribe` and `xit`",
         type: "functionality",
         typescriptOnly: false,
     };
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithFunction(sourceFile, walk);
+        // return this.applyWithFunction(sourceFile, walk);
+        return this.applyWithWalker(new DefocusWalker(sourceFile, this.ruleName, {
+            deexclude: this.ruleArguments.indexOf("deexclude") !== -1,
+        }));
     }
 }
 
-function walk(ctx: Lint.WalkContext<void>) {
-    return ts.forEachChild(ctx.sourceFile, function cb(node: ts.Node): void {
-        if (node.kind === ts.SyntaxKind.CallExpression) {
-            const expression = (node as ts.CallExpression).expression;
-            const functionName = expression.getText();
-            bannedFunctions.forEach((banned) => {
-                if (banned === functionName) {
-                    ctx.addFailureAtNode(expression, failureMessage(functionName));
+// tslint:disable-next-line:max-classes-per-file
+class DefocusWalker extends Lint.AbstractWalker<Options> {
+    public walk(sourceFile: ts.SourceFile): void {
+
+        const cb = (node: ts.Node): void => {
+            if (node.kind === ts.SyntaxKind.CallExpression) {
+                const expression = (node as ts.CallExpression).expression;
+                const functionName = expression.getText();
+                bannedFunctions.forEach((banned) => {
+                    if (banned === functionName) {
+                        this.addFailureAtNode(expression, failureMessage(functionName));
+                    }
+                });
+                if (this.options.deexclude) {
+                    bannedExcludeFunctions.forEach((banned) => {
+                        if (banned === functionName) {
+                            this.addFailureAtNode(expression, failureMessage(functionName));
+                        }
+                    });
                 }
-            });
-        }
-        return ts.forEachChild(node, cb);
-    });
+            }
+            return ts.forEachChild(node, cb);
+        };
+        return ts.forEachChild(sourceFile, cb);
+    }
 }
 
 const bannedFunctions: ReadonlyArray<string> = ["fdescribe", "fit"];
+const bannedExcludeFunctions: ReadonlyArray<string> = ["xdescribe", "xit"];
 
 const failureMessage = (functionName: string) => {
     return `Calls to '${functionName}' are not allowed.`;

--- a/src/test/rules/defocus/test.ts.lint
+++ b/src/test/rules/defocus/test.ts.lint
@@ -17,9 +17,21 @@ fdescribe(() => {
     ~~~                 [Calls to 'fit' are not allowed.]
 });
 
+xdescribe(() => {
+~~~~~~~~~               [Calls to 'xdescribe' are not allowed.]
+    xit(() => {});
+    ~~~                 [Calls to 'xit' are not allowed.]
+});
+
 describe(() => {
     fdescribe(() => {
     ~~~~~~~~~           [Calls to 'fdescribe' are not allowed.]
+    });
+});
+
+describe(() => {
+    xdescribe(() => {
+    ~~~~~~~~~           [Calls to 'xdescribe' are not allowed.]
     });
 });
 
@@ -33,13 +45,18 @@ abcdefdescribe(function(){
 
 function(){
     console.log('fit', 'function');
+    console.log('xit', 'function');
 }
 
 export class Test {
     constructor() {
         this.fdescribe();
+        this.xdescribe();
     }
     
     public fdescribe(): void {
+    }
+
+    public xdescribe(): void {
     }
 }

--- a/src/test/rules/defocus/tslint.json
+++ b/src/test/rules/defocus/tslint.json
@@ -1,6 +1,9 @@
 {
   "rulesDirectory": "../../../../dist",
   "rules": {
-    "defocus": true
+    "defocus": [
+        true,
+        "deexclude"
+    ]
   }
 }

--- a/src/test/specs/defocusRule.spec.ts
+++ b/src/test/specs/defocusRule.spec.ts
@@ -10,9 +10,9 @@ const ruleName = 'defocus';
 
 const ruleOptions: Readonly<Lint.IOptions> = {
     disabledIntervals: [],
-    ruleArguments: [],
+    ruleArguments: ["deexclude"],
     ruleName,
-    ruleSeverity: "error"
+    ruleSeverity: "error",
 };
 
 describe(ruleName, function test() {
@@ -24,11 +24,25 @@ describe(ruleName, function test() {
         expect(failures[0].getFailure()).eq('Calls to \'fdescribe\' are not allowed.');
     });
 
+    it('should fail when "xdescribe" is called', () => {
+        const sourceFile = getSourceFile('shouldFailWhenXDescribeCalled.ts');
+        const failures = new Rule(ruleOptions).apply(sourceFile);
+        expect(failures).length(1);
+        expect(failures[0].getFailure()).eq('Calls to \'xdescribe\' are not allowed.');
+    });
+
     it('should fail when "fit" is called', () => {
         const sourceFile = getSourceFile('shouldFailWhenFitCalled.ts');
         const failures = new Rule(ruleOptions).apply(sourceFile);
         expect(failures).length(1);
         expect(failures[0].getFailure()).eq('Calls to \'fit\' are not allowed.');
+    });
+
+    it('should fail when "xit" is called', () => {
+        const sourceFile = getSourceFile('shouldFailWhenXitCalled.ts');
+        const failures = new Rule(ruleOptions).apply(sourceFile);
+        expect(failures).length(1);
+        expect(failures[0].getFailure()).eq('Calls to \'xit\' are not allowed.');
     });
 
     it('should not fail for a snippet without "fit" or "fdescribe"', () => {
@@ -43,14 +57,32 @@ describe(ruleName, function test() {
         expect(failures).length(0);
     });
 
+    it('should not flag a false alert if "xdescribe" appears as a variable name', () => {
+        const sourceFile = getSourceFile('allowsXDescribeAsVariableName.ts');
+        const failures = new Rule(ruleOptions).apply(sourceFile);
+        expect(failures).length(0);
+    });
+
     it('should not flag a false alert if "fit" appears as a object property key or value', () => {
         const sourceFile = getSourceFile('allowsFitAsPropKeyValue.ts');
         const failures = new Rule(ruleOptions).apply(sourceFile);
         expect(failures).length(0);
     });
 
+    it('should not flag a false alert if "xit" appears as a object property key or value', () => {
+        const sourceFile = getSourceFile('allowsXitAsPropKeyValue.ts');
+        const failures = new Rule(ruleOptions).apply(sourceFile);
+        expect(failures).length(0);
+    });
+
     it('should not flag a false alert if "fdescribe" or "fit" appear as function parameters', () => {
         const sourceFile = getSourceFile('allowsFDescribeFitAsFunctionParams.ts');
+        const failures = new Rule(ruleOptions).apply(sourceFile);
+        expect(failures).length(0);
+    });
+
+    it('should not flag a false alert if "xdescribe" or "xit" appear as function parameters', () => {
+        const sourceFile = getSourceFile('allowsXDescribeXitAsFunctionParams.ts');
         const failures = new Rule(ruleOptions).apply(sourceFile);
         expect(failures).length(0);
     });

--- a/src/test/specs/snippets/allowsXDescribeAsVariableName.ts
+++ b/src/test/specs/snippets/allowsXDescribeAsVariableName.ts
@@ -1,0 +1,1 @@
+const xdescribe = {test: 123}

--- a/src/test/specs/snippets/allowsXDescribeXitAsFunctionParams.ts
+++ b/src/test/specs/snippets/allowsXDescribeXitAsFunctionParams.ts
@@ -1,0 +1,3 @@
+function (xdescribe, xit) {
+    console.log(xdescribe, xit);
+}();

--- a/src/test/specs/snippets/allowsXitAsPropKeyValue.ts
+++ b/src/test/specs/snippets/allowsXitAsPropKeyValue.ts
@@ -1,0 +1,1 @@
+let testObject = {xit: "test", test: "xit"}

--- a/src/test/specs/snippets/shouldFailWhenXDescribeCalled.ts
+++ b/src/test/specs/snippets/shouldFailWhenXDescribeCalled.ts
@@ -1,0 +1,3 @@
+xdescribe(() => {
+    console.log("testing")
+});

--- a/src/test/specs/snippets/shouldFailWhenXitCalled.ts
+++ b/src/test/specs/snippets/shouldFailWhenXitCalled.ts
@@ -1,0 +1,5 @@
+describe(() => {
+    xit(() => {
+        console.log("testing")
+    });
+});


### PR DESCRIPTION
In order to warn for `xdescribe` and `xit`.

No breaking change, just need to change the `.tslint.json` file:
```
"defocus": [true, "deexclude"]
```