### PR TITLE
Fix for use in shared libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This is a tslint rule that warns about focussed Jasmine tests - fdescribe and fi
 
 ## Usage
 * Install with: `npm install tslint-defocus --save-dev`
-* Add the rule to your `.tslint.json` file:
+* Extend this package in your `.tslint.json` file, e.g.:
 ```
-  "rulesDirectory": "./node_modules/tslint-defocus/dist",
+  "extends": [
+    "tslint-defocus"
+  ],
   "rules": {
     "defocus": true,
     ...

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    rulesDirectory: "dist",
+};

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
   "license": "MIT",
   "version": "2.0.3",
   "dependencies": {
-    "es6-shim": "^0.35.0",
-    "tslint": "^5.4.3",
-    "typescript": "^2.4.1"
+    "es6-shim": "^0.35.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
@@ -41,7 +39,13 @@
     "gulp-typescript": "^3.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.0",
-    "run-sequence": "^2.0.0"
+    "run-sequence": "^2.0.0",
+    "tslint": "^5.4.3",
+    "typescript": "^2.4.1"
+  },
+  "peerDependencies": {
+    "tslint": "^5.4.3",
+    "typescript": "^2.4.1"
   },
   "scripts": {
     "clean": "gulp clean",


### PR DESCRIPTION
This PR enables `tslint-defocus` for use in shared libraries, to address https://github.com/Sergiioo/tslint-defocus/issues/5.

This is a very similar change to that made for other TS Lint extension libraries, e.g. see https://github.com/buzinas/tslint-eslint-rules/issues/165 and https://github.com/palantir/tslint-react.

This PR also moves some dependencies to dev/peer dependencies, to fix an issue where the defocus rule may be silently ignored for projects in a monorepo with multiple versions of typescript in use.

After this change, the package may be consumed not only via `rulesDirectory` but also via:
```
{
  "extends": [
    "tslint-defocus"
  ],
  "rules": {
    "defocus": true
  }
```
